### PR TITLE
Universalize the shebang

### DIFF
--- a/cdux
+++ b/cdux
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 
 # skips - stores arguments to be skipped
 skips=""


### PR DESCRIPTION
`#!/usr/bin/bash` doesn't work on NixOS, and possibly other niche systems.

`#!/usr/bin/env bash` works everywhere.